### PR TITLE
PR: Add a .coveragerc file to exclude testing code from coverage analysis

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,15 @@
+[run]
+omit = 
+    */tests/*
+data_file = .coverage
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run
+    if __name__ == .__main__.:
+
+fail_under=0


### PR DESCRIPTION
This PR proposes to exclude code from tests and under `if __name__ == '__main__':` from the coverage analysis.