### PR TITLE
PR: Update coveralls badge

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 
 [![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)](https://www.python.org/downloads/release/python-360/)
-[![Coverage Status](https://coveralls.io/repos/github/x-malet/scientific_file_reader/badge.svg?branch=master)](https://coveralls.io/github/x-malet/scientific_file_reader?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/x-malet/HydroSensorReader/badge.svg?branch=master)](https://coveralls.io/github/x-malet/HydroSensorReader?branch=master)
 
 [![Build Status](https://travis-ci.org/x-malet/HydroSensorReader.svg?branch=master)](https://travis-ci.org/x-malet/HydroSensorReader)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/2818f21a4dcd493a83aeb8aa83885395)](https://www.codacy.com/app/maletxa/HydroSensorReader?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=x-malet/HydroSensorReader&amp;utm_campaign=Badge_Grade)


### PR DESCRIPTION
Simply updates the Coveralls badge info to take into account the new name of the repo so that it is correctly updated on the Readme.